### PR TITLE
Reduce selection of special chars in baseO

### DIFF
--- a/core/src/index.js
+++ b/core/src/index.js
@@ -50,7 +50,7 @@ const templatesBase = {
 const baseV = "AEIOU";
 const baseC = "BCDFGHJKLMNPQRSTVWXYZ";
 const baseN = "0123456789";
-const baseO = "@&%?,=[]_:-+*$#!'^~;()/.";
+const baseO = "!@#$%^&*()";
 const templateChars = {
 	V: baseV,
 	C: baseC,


### PR DESCRIPTION
Beside the fact that some of these characters might be problematic, it's better to have a full compatibility with the original version of MasterPassword.

fixes Cretezy/MasterPassX#5